### PR TITLE
Pass `$field` to fromBuilder for have the config accessible in custom…

### DIFF
--- a/src/Services/FormMaker.php
+++ b/src/Services/FormMaker.php
@@ -284,6 +284,7 @@ class FormMaker
                 'labelFor' => ucfirst($column),
                 'label' => $this->columnLabel($field, $column),
                 'input' => $input,
+                'field' => $field,
                 'errorMessage' => $this->errorMessage($errorMessage),
                 'errorHighlight' => $errorHighlight,
             ]);


### PR DESCRIPTION
… view

Added `$field` var to the View::make array for have the config of field accessible. 
Example: 
I define an array of fields configuration and put in it a extra_class or something else
```
'in_promotion' => [
    'type' => '
    'class' => 'flat',
    'extra_class' => 'col-sm-6', // <-------- custom
],
```
Now in my view template i can access the extra_class:
```
<div class="{{ $field['extra_class'] or 'col-sm-12' }}"> // <-------- custom
    <div class="form-group {{ $errorHighlight }}">
        <label class="control-label" for="{!! $labelFor !!}">{!! $label !!}</label>
        {!! $input !!}
    </div>
    {!! $errorMessage !!}
</div>
```